### PR TITLE
feat(container): add socket-level framing and Open batching

### DIFF
--- a/container/host_cmd_linux.go
+++ b/container/host_cmd_linux.go
@@ -10,6 +10,11 @@ import (
 	"github.com/criyle/go-sandbox/pkg/unixsocket"
 )
 
+// maxOpenPerBatch limits the number of files opened in a single batch to stay
+// under the Linux SCM_MAX_FD (253) kernel limit for sendmsg SCM_RIGHTS.
+// 200 leaves a safe margin.
+const maxOpenPerBatch = 200
+
 // Ping send ping message to container, wait for 3 second before timeout
 func (c *container) Ping() error {
 	c.mu.Lock()
@@ -54,27 +59,8 @@ func (c *container) Open(p []OpenCmd) (results []OpenCmdResult, err error) {
 	syscall.ForkLock.RLock()
 	defer syscall.ForkLock.RUnlock()
 
-	// send copyin
-	cmd := cmd{
-		Cmd:     cmdOpen,
-		OpenCmd: p,
-	}
-	if err := c.sendCmd(cmd, unixsocket.Msg{}); err != nil {
-		return nil, fmt.Errorf("open: %w", err)
-	}
-	reply, msg, err := c.recvReply()
-	if err != nil {
-		return nil, fmt.Errorf("open: %w", err)
-	}
-	if reply.Error != nil {
-		return nil, fmt.Errorf("open: container error: %v", reply.Error)
-	}
-	fdIndex := 0
 	defer func() {
 		if err != nil {
-			if fdIndex < len(msg.Fds) {
-				closeFds(msg.Fds[fdIndex:])
-			}
 			for _, res := range results {
 				if res.File != nil {
 					res.File.Close()
@@ -82,28 +68,55 @@ func (c *container) Open(p []OpenCmd) (results []OpenCmdResult, err error) {
 			}
 		}
 	}()
-	if len(reply.BatchErrors) != len(p) {
-		return nil, fmt.Errorf("open: response length mismatch: got %d, want %d", len(reply.BatchErrors), len(p))
-	}
 
+	// send copyin in batches to stay under the SCM_MAX_FD kernel limit
 	results = make([]OpenCmdResult, len(p))
-	for i, errStr := range reply.BatchErrors {
-		if errStr != "" {
-			// This specific file failed to open
-			results[i] = OpenCmdResult{Err: errors.New(errStr)}
-			continue
+	for offset := 0; offset < len(p); offset += maxOpenPerBatch {
+		end := offset + maxOpenPerBatch
+		if end > len(p) {
+			end = len(p)
 		}
-		if fdIndex >= len(msg.Fds) {
-			return nil, fmt.Errorf("open: mismatch between success flags and received FDs")
+		cmd := cmd{
+			Cmd:     cmdOpen,
+			OpenCmd: p[offset:end],
 		}
-		fd := msg.Fds[fdIndex]
-		fdIndex++
-		syscall.CloseOnExec(fd)
-		f := os.NewFile(uintptr(fd), p[i].Path)
-		if f == nil {
-			return nil, fmt.Errorf("open: failed to create file for fd: %d", fd)
+		if err := c.sendCmd(cmd, unixsocket.Msg{}); err != nil {
+			return nil, fmt.Errorf("open: %w", err)
 		}
-		results[i] = OpenCmdResult{File: f}
+		reply, msg, err := c.recvReply()
+		if err != nil {
+			return nil, fmt.Errorf("open: %w", err)
+		}
+		if reply.Error != nil {
+			closeFds(msg.Fds)
+			return nil, fmt.Errorf("open: container error: %v", reply.Error)
+		}
+		if len(reply.BatchErrors) != end-offset {
+			closeFds(msg.Fds)
+			return nil, fmt.Errorf("open: response length mismatch: got %d, want %d", len(reply.BatchErrors), end-offset)
+		}
+
+		fdIndex := 0
+		for i, errStr := range reply.BatchErrors {
+			if errStr != "" {
+				// This specific file failed to open
+				results[offset+i] = OpenCmdResult{Err: errors.New(errStr)}
+				continue
+			}
+			if fdIndex >= len(msg.Fds) {
+				closeFds(msg.Fds[fdIndex:])
+				return nil, fmt.Errorf("open: mismatch between success flags and received FDs")
+			}
+			fd := msg.Fds[fdIndex]
+			fdIndex++
+			syscall.CloseOnExec(fd)
+			f := os.NewFile(uintptr(fd), p[offset+i].Path)
+			if f == nil {
+				closeFds(msg.Fds[fdIndex:])
+				return nil, fmt.Errorf("open: failed to create file for fd: %d", fd)
+			}
+			results[offset+i] = OpenCmdResult{File: f}
+		}
 	}
 	return results, nil
 }

--- a/container/socket_bench_test.go
+++ b/container/socket_bench_test.go
@@ -1,0 +1,231 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/criyle/go-sandbox/pkg/unixsocket"
+)
+
+// benchDrainBuffer is large enough to receive any single datagram sent by the
+// benchmarks below (largest payload is ~128KB) plus headroom.
+const benchDrainBuffer = 256 << 10
+
+// BenchmarkSocketPing measures a full ping round-trip (small message hot path).
+func BenchmarkSocketPing(b *testing.B) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srv := newSocket(server)
+	cli := newSocket(client)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			var in cmd
+			if _, err := srv.RecvMsg(&in); err != nil {
+				return
+			}
+			if err := srv.SendMsg(reply{}, unixsocket.Msg{}); err != nil {
+				return
+			}
+		}
+	}()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := cli.SendMsg(cmd{Cmd: cmdPing}, unixsocket.Msg{}); err != nil {
+			b.Fatal(err)
+		}
+		var out reply
+		if _, err := cli.RecvMsg(&out); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	server.Close()
+	<-done
+}
+
+// BenchmarkSocketSendSmall measures send+gob-encode cost for a tiny message
+// with a fast kernel-level drain. This represents the hot-path cost, which
+// should stay identical to the pre-framing baseline (small messages are sent
+// as-is with no chunk header).
+func BenchmarkSocketSendSmall(b *testing.B) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	cli := newSocket(client)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, benchDrainBuffer)
+		close(ready)
+		for {
+			_, _, err := server.RecvMsg(buf)
+			if err != nil {
+				return
+			}
+		}
+	}()
+	<-ready
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := cli.SendMsg(cmd{Cmd: cmdPing}, unixsocket.Msg{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	server.Close()
+	<-done
+}
+
+// BenchmarkSocketSendLarge measures send cost for messages of increasing size,
+// including those that cross the 32KB buffer boundary and are split into chunks.
+func BenchmarkSocketSendLarge(b *testing.B) {
+	sizes := []struct {
+		name    string
+		paths   int
+		pathLen int
+	}{
+		{"tiny_10paths", 10, 50}, // well under 32KB, single datagram, no chunks
+		{"near_32KB", 200, 140},  // ~32KB gob, near boundary
+		{"64KB", 400, 140},       // split into chunks
+		{"128KB", 800, 140},      // split into chunks
+	}
+
+	for _, tc := range sizes {
+		b.Run(tc.name, func(b *testing.B) {
+			server, client, err := unixsocket.NewSocketPair()
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer server.Close()
+			defer client.Close()
+
+			cli := newSocket(client)
+
+			paths := make([]OpenCmd, tc.paths)
+			for i := range paths {
+				paths[i] = OpenCmd{
+					Path: "/tmp/" + strings.Repeat("p", tc.pathLen) + fmt.Sprintf("_%d", i),
+				}
+			}
+			sendCmd := cmd{Cmd: cmdOpen, OpenCmd: paths}
+
+			ready := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				buf := make([]byte, benchDrainBuffer)
+				close(ready)
+				for {
+					_, _, err := server.RecvMsg(buf)
+					if err != nil {
+						return
+					}
+				}
+			}()
+			<-ready
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := cli.SendMsg(sendCmd, unixsocket.Msg{}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			server.Close()
+			<-done
+		})
+	}
+}
+
+// BenchmarkSocketOpenRoundTrip measures end-to-end open round-trip with real
+// files and FD passing across the socket. Exercises both gob encoding size
+// and FD batch limits (SCM_MAX_FD=253).
+func BenchmarkSocketOpenRoundTrip(b *testing.B) {
+	tmpDir := b.TempDir()
+	for _, n := range []int{10, 100, 200, 500} {
+		b.Run(fmt.Sprintf("%d_files", n), func(b *testing.B) {
+			dir := filepath.Join(tmpDir, fmt.Sprintf("n%d", n))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				b.Fatal(err)
+			}
+			args := make([]OpenCmd, n)
+			for j := 0; j < n; j++ {
+				p := filepath.Join(dir, fmt.Sprintf("f%d", j))
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					b.Fatal(err)
+				}
+				args[j] = OpenCmd{Path: p, Flag: os.O_RDONLY, Perm: 0}
+			}
+
+			server, client, err := unixsocket.NewSocketPair()
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer server.Close()
+			defer client.Close()
+			srv := newSocket(server)
+			cli := newSocket(client)
+
+			serveDone := make(chan struct{})
+			go func() {
+				defer close(serveDone)
+				for {
+					var in cmd
+					msg, err := srv.RecvMsg(&in)
+					if err != nil {
+						return
+					}
+					fds := make([]int, 0, len(in.OpenCmd))
+					closeFds(msg.Fds)
+					for _, o := range in.OpenCmd {
+						f, e := os.OpenFile(o.Path, o.Flag, o.Perm)
+						if e != nil {
+							continue
+						}
+						fds = append(fds, int(f.Fd()))
+					}
+					_ = srv.SendMsg(reply{}, unixsocket.Msg{Fds: fds})
+				}
+			}()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := cli.SendMsg(cmd{Cmd: cmdOpen, OpenCmd: args}, unixsocket.Msg{}); err != nil {
+					b.Fatal(err)
+				}
+				var r reply
+				recvMsg, err := cli.RecvMsg(&r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				closeFds(recvMsg.Fds)
+			}
+			b.StopTimer()
+			server.Close()
+			<-serveDone
+		})
+	}
+}

--- a/container/socket_framing_error_test.go
+++ b/container/socket_framing_error_test.go
@@ -1,0 +1,214 @@
+package container
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/criyle/go-sandbox/pkg/unixsocket"
+)
+
+// sendRawChunk writes a raw [chunkByte][flag][payload] chunk datagram for testing.
+func sendRawChunk(t *testing.T, s *unixsocket.Socket, flag byte, payload []byte, fds []int) {
+	t.Helper()
+	frame := make([]byte, chunkHeaderSize+len(payload))
+	frame[0] = chunkByte
+	frame[1] = flag
+	copy(frame[chunkHeaderSize:], payload)
+	msg := unixsocket.Msg{}
+	if len(fds) > 0 {
+		msg.Fds = fds
+	}
+	if err := s.SendMsg(frame, msg); err != nil {
+		t.Fatalf("sendRawChunk: %v", err)
+	}
+}
+
+// TestChunkUnexpectedFDsInLaterChunk verifies FDs carried on a non-first chunk
+// are closed and rejected (FDs only travel with the first chunk).
+func TestChunkUnexpectedFDsInLaterChunk(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	cli := newSocket(client)
+
+	pipe := make([]int, 2)
+	openPipe(t, pipe)
+	defer closeFds(pipe)
+
+	// First chunk (partial) without FDs, second chunk carries unexpected FDs.
+	sendRawChunk(t, server, chunkPartial, []byte("hello"), nil)
+	sendRawChunk(t, server, chunkComplete, []byte("world"), []int{pipe[0]})
+
+	var out cmd
+	_, err = cli.RecvMsg(&out)
+	if err == nil {
+		t.Fatal("expected error for unexpected FDs in chunk, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected FDs") {
+		t.Errorf("error = %v, want contains 'unexpected FDs'", err)
+	}
+}
+
+// TestChunkedMediumRoundTrip verifies a message a few hundred KB in size is
+// chunked and reassembled correctly (multiple partial chunks + one complete).
+func TestChunkedMediumRoundTrip(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	cli := newSocket(client)
+
+	paths := make([]OpenCmd, 2000)
+	for i := range paths {
+		paths[i] = OpenCmd{Path: "/w/" + strings.Repeat("p", 200)}
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		var c cmd
+		_, e := newSocket(server).RecvMsg(&c)
+		if e == nil && len(c.OpenCmd) != 2000 {
+			t.Errorf("got %d cmds, want 2000", len(c.OpenCmd))
+		}
+		errCh <- e
+	}()
+	if err := cli.SendMsg(cmd{Cmd: cmdOpen, OpenCmd: paths}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("send large chunked: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("recv large chunked: %v", err)
+	}
+}
+
+// TestChunkRoundTripLarge sends a message far larger than a single datagram and
+// verifies it is chunked and reassembled intact, then a small message still works.
+func TestChunkRoundTripLarge(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srv := newSocket(server)
+	cli := newSocket(client)
+
+	// ~3000 paths of 200 chars -> hundreds of KB, many chunks.
+	paths := make([]OpenCmd, 3000)
+	for i := range paths {
+		paths[i] = OpenCmd{Path: "/w/" + strings.Repeat("z", 200)}
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		var c cmd
+		if _, e := srv.RecvMsg(&c); e != nil {
+			errCh <- e
+			return
+		}
+		if len(c.OpenCmd) != 3000 {
+			t.Errorf("large: got %d cmds, want 3000", len(c.OpenCmd))
+		}
+		// A small message after a large one must still work (assembly buffer reset).
+		var c2 cmd
+		_, e := srv.RecvMsg(&c2)
+		if e == nil && c2.Cmd != cmdPing {
+			t.Errorf("small after large: got cmd %d, want cmdPing", c2.Cmd)
+		}
+		errCh <- e
+	}()
+
+	if err := cli.SendMsg(cmd{Cmd: cmdOpen, OpenCmd: paths}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("send large: %v", err)
+	}
+	if err := cli.SendMsg(cmd{Cmd: cmdPing}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("send small after large: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+}
+
+// TestChunkUnlimitedSize verifies a message several MB in size (far beyond a
+// single SEQPACKET datagram / the default kernel socket buffer) round-trips
+// intact, proving chunking has no practical size ceiling and needs no kernel
+// buffer tuning.
+func TestChunkUnlimitedSize(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srv := newSocket(server)
+	cli := newSocket(client)
+
+	// ~40000 paths of 200 chars -> ~8MB gob, hundreds of chunks, well past the
+	// ~200KB single-datagram kernel limit.
+	paths := make([]OpenCmd, 40000)
+	for i := range paths {
+		paths[i] = OpenCmd{Path: "/w/" + strings.Repeat("u", 200)}
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		var c cmd
+		_, e := srv.RecvMsg(&c)
+		if e == nil && len(c.OpenCmd) != 40000 {
+			t.Errorf("got %d cmds, want 40000", len(c.OpenCmd))
+		}
+		errCh <- e
+	}()
+
+	if err := cli.SendMsg(cmd{Cmd: cmdOpen, OpenCmd: paths}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("send multi-MB: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("recv multi-MB: %v", err)
+	}
+}
+
+// TestSmallMessageNoChunkHeader verifies small messages are sent raw with no
+// chunk header: a direct raw recv sees a first byte that is not chunkByte.
+func TestSmallMessageNoChunkHeader(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	cli := newSocket(client)
+
+	if err := cli.SendMsg(cmd{Cmd: cmdPing}, unixsocket.Msg{}); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, bufferSize)
+	n, _, err := server.RecvMsg(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n < 1 {
+		t.Fatal("empty datagram")
+	}
+	if buf[0] == chunkByte {
+		t.Errorf("small message unexpectedly sent as a chunk (first byte=0x%02x)", buf[0])
+	}
+}
+
+// openPipe is a helper to create a pipe for FD passing tests
+func openPipe(t *testing.T, p []int) {
+	t.Helper()
+	if err := syscall.Pipe2(p, syscall.O_CLOEXEC); err != nil {
+		t.Fatalf("pipe2: %v", err)
+	}
+}

--- a/container/socket_framing_test.go
+++ b/container/socket_framing_test.go
@@ -1,0 +1,202 @@
+package container
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/criyle/go-sandbox/pkg/unixsocket"
+)
+
+func TestSocketFramingSingle(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srvSock := newSocket(server)
+	cliSock := newSocket(client)
+
+	// Send a small cmd (single frame)
+	sendCmd := cmd{Cmd: cmdPing}
+	if err := cliSock.SendMsg(sendCmd, unixsocket.Msg{}); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+
+	var recvCmd cmd
+	msg, err := srvSock.RecvMsg(&recvCmd)
+	if err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if recvCmd.Cmd != cmdPing {
+		t.Errorf("got cmd %d, want %d", recvCmd.Cmd, cmdPing)
+	}
+	if len(msg.Fds) != 0 {
+		t.Errorf("unexpected fds: %d", len(msg.Fds))
+	}
+
+	// Send reply
+	if err := srvSock.SendMsg(reply{}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("SendMsg reply: %v", err)
+	}
+	var recvReply reply
+	if _, err := cliSock.RecvMsg(&recvReply); err != nil {
+		t.Fatalf("RecvMsg reply: %v", err)
+	}
+}
+
+func TestSocketFramingLargeMessage(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srvSock := newSocket(server)
+	cliSock := newSocket(client)
+
+	// Create a large message that exceeds 32KB to trigger chunking
+	// Use long paths in OpenCmd to inflate GOB size
+	lotsOfPaths := make([]OpenCmd, 0, 500)
+	for i := 0; i < 500; i++ {
+		lotsOfPaths = append(lotsOfPaths, OpenCmd{
+			Path:     strings.Repeat("a", 100) + "_file_" + string(rune('A'+i%26)),
+			Flag:     0,
+			Perm:     0644,
+			MkdirAll: true,
+		})
+	}
+
+	sendCmd := cmd{
+		Cmd:     cmdOpen,
+		OpenCmd: lotsOfPaths,
+	}
+
+	errCh := make(chan error, 1)
+	var recvCmd cmd
+	go func() {
+		_, err := srvSock.RecvMsg(&recvCmd)
+		errCh <- err
+	}()
+
+	if err := cliSock.SendMsg(sendCmd, unixsocket.Msg{}); err != nil {
+		t.Fatalf("SendMsg large: %v", err)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("RecvMsg large: %v", err)
+	}
+
+	if recvCmd.Cmd != cmdOpen {
+		t.Errorf("got cmd %d, want %d", recvCmd.Cmd, cmdOpen)
+	}
+	if len(recvCmd.OpenCmd) != 500 {
+		t.Errorf("got %d OpenCmds, want 500", len(recvCmd.OpenCmd))
+	}
+	// Verify first and last paths
+	if len(recvCmd.OpenCmd) > 0 {
+		expected := strings.Repeat("a", 100) + "_file_" + string(rune('A'))
+		if !strings.HasPrefix(recvCmd.OpenCmd[0].Path, strings.Repeat("a", 100)) {
+			t.Errorf("first path corrupted: %q", recvCmd.OpenCmd[0].Path)
+		}
+		_ = expected
+	}
+}
+
+func TestSocketFramingRoundTrip(t *testing.T) {
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srvSock := newSocket(server)
+	cliSock := newSocket(client)
+
+	// Send multiple messages alternating directions to verify state is clean
+	for i := 0; i < 10; i++ {
+		c := cmd{Cmd: cmdPing}
+		if err := cliSock.SendMsg(c, unixsocket.Msg{}); err != nil {
+			t.Fatalf("SendMsg ping %d: %v", i, err)
+		}
+		var rc cmd
+		if _, err := srvSock.RecvMsg(&rc); err != nil {
+			t.Fatalf("RecvMsg ping %d: %v", i, err)
+		}
+		if rc.Cmd != cmdPing {
+			t.Errorf("iter %d: got cmd %d, want %d", i, rc.Cmd, cmdPing)
+		}
+
+		// Reply
+		if err := srvSock.SendMsg(reply{}, unixsocket.Msg{}); err != nil {
+			t.Fatalf("SendMsg reply %d: %v", i, err)
+		}
+		var rr reply
+		if _, err := cliSock.RecvMsg(&rr); err != nil {
+			t.Fatalf("RecvMsg reply %d: %v", i, err)
+		}
+	}
+}
+
+func TestSocketFramingLargeThenSmall(t *testing.T) {
+	// Verify that after a chunked message, small messages still work
+	server, client, err := unixsocket.NewSocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	defer client.Close()
+
+	srvSock := newSocket(server)
+	cliSock := newSocket(client)
+
+	// Send large message first
+	largePaths := make([]OpenCmd, 400)
+	for i := range largePaths {
+		largePaths[i] = OpenCmd{Path: "/w/" + strings.Repeat("x", 80)}
+	}
+
+	largeCmd := cmd{Cmd: cmdOpen, OpenCmd: largePaths}
+
+	errCh := make(chan error, 1)
+	go func() {
+		var rc cmd
+		_, err := srvSock.RecvMsg(&rc)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if len(rc.OpenCmd) != 400 {
+			errCh <- err
+			return
+		}
+		// Reply
+		errCh <- srvSock.SendMsg(reply{}, unixsocket.Msg{})
+	}()
+
+	if err := cliSock.SendMsg(largeCmd, unixsocket.Msg{}); err != nil {
+		t.Fatalf("SendMsg large: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("large msg error: %v", err)
+	}
+	var lr reply
+	if _, err := cliSock.RecvMsg(&lr); err != nil {
+		t.Fatalf("RecvMsg large reply: %v", err)
+	}
+
+	// Now send a small message (ping) - should work (no leftover chunk state)
+	if err := cliSock.SendMsg(cmd{Cmd: cmdPing}, unixsocket.Msg{}); err != nil {
+		t.Fatalf("SendMsg ping after large: %v", err)
+	}
+	var pc cmd
+	if _, err := srvSock.RecvMsg(&pc); err != nil {
+		t.Fatalf("RecvMsg ping after large: %v", err)
+	}
+	if pc.Cmd != cmdPing {
+		t.Errorf("after large msg, got cmd %d, want %d", pc.Cmd, cmdPing)
+	}
+}

--- a/container/socket_linux.go
+++ b/container/socket_linux.go
@@ -11,6 +11,23 @@ import (
 // 32k buffer size
 const bufferSize = 32 << 10
 
+// Chunk framing for messages larger than bufferSize. A gob stream never starts
+// with a zero byte (its leading length prefix is always >= 1), so a leading
+// chunkByte unambiguously marks a chunk and small messages need no header at
+// all. Each chunk datagram is [chunkByte][flag][payload] and stays within
+// bufferSize, so it always fits the default kernel socket buffer regardless of
+// the total message size.
+const (
+	chunkByte        = 0 // sentinel first byte marking a chunk datagram
+	chunkHeaderSize  = 2 // [chunkByte][flag]
+	chunkPayloadSize = bufferSize - chunkHeaderSize
+)
+
+const (
+	chunkPartial  byte = 0 // more chunks follow
+	chunkComplete byte = 1 // final chunk of the message
+)
+
 type socket struct {
 	*unixsocket.Socket
 
@@ -21,6 +38,9 @@ type socket struct {
 
 	encoder  *gob.Encoder
 	sendBuff bytes.Buffer
+
+	chunkBuff []byte       // reusable framing buffer for sending chunks
+	recvChunk bytes.Buffer // reusable assembly buffer for receiving chunks
 }
 
 // bufferRotator replace the underlying Buffers to avoid allocation
@@ -48,6 +68,36 @@ func (s *socket) RecvMsg(e any) (msg unixsocket.Msg, err error) {
 	if err != nil {
 		return msg, fmt.Errorf("recv msg: %w", err)
 	}
+	// A leading chunkByte marks a chunk of a larger message; gob output never
+	// starts with a zero byte, so small messages are received as-is with no
+	// extra copy. Chunks are reassembled until the complete flag is seen, and
+	// the returned msg carries the FDs from the first chunk.
+	if n >= chunkHeaderSize && s.buff[0] == chunkByte {
+		s.recvChunk.Reset()
+		flag := s.buff[1]
+		s.recvChunk.Write(s.buff[chunkHeaderSize:n])
+		for flag != chunkComplete {
+			cn, cmsg, cerr := s.Socket.RecvMsg(s.buff)
+			if cerr != nil {
+				return cmsg, fmt.Errorf("recv msg: chunk: %w", cerr)
+			}
+			if cn < chunkHeaderSize || s.buff[0] != chunkByte {
+				return cmsg, fmt.Errorf("recv msg: expected chunk, got %d bytes", cn)
+			}
+			if len(cmsg.Fds) > 0 {
+				// FDs only travel with the first chunk; close unexpected ones.
+				closeFds(cmsg.Fds)
+				return cmsg, fmt.Errorf("recv msg: unexpected FDs in chunk")
+			}
+			flag = s.buff[1]
+			s.recvChunk.Write(s.buff[chunkHeaderSize:cn])
+		}
+		s.recvBuff.Rotate(bytes.NewBuffer(s.recvChunk.Bytes()))
+		if err := s.decoder.Decode(e); err != nil {
+			return msg, fmt.Errorf("recv msg: decode: %w", err)
+		}
+		return msg, nil
+	}
 	s.recvBuff.Rotate(bytes.NewBuffer(s.buff[:n]))
 
 	if err := s.decoder.Decode(e); err != nil {
@@ -61,12 +111,39 @@ func (s *socket) SendMsg(e any, msg unixsocket.Msg) error {
 	if err := s.encoder.Encode(e); err != nil {
 		return fmt.Errorf("send msg: encode: %w", err)
 	}
-	if s.sendBuff.Len() > bufferSize {
-		return fmt.Errorf("send msg: payload too large: %d > %d", s.sendBuff.Len(), bufferSize)
+	data := s.sendBuff.Bytes()
+	// Small messages fit in a single datagram and are sent as-is (zero copy);
+	// larger ones are split into [chunkByte][flag][payload] chunks, each within
+	// bufferSize so it always fits the receiver's buffer.
+	if len(data) <= bufferSize {
+		if err := s.Socket.SendMsg(data, msg); err != nil {
+			return fmt.Errorf("send msg: %w", err)
+		}
+		return nil
 	}
-
-	if err := s.Socket.SendMsg(s.sendBuff.Bytes(), msg); err != nil {
-		return fmt.Errorf("send msg: %w", err)
+	if s.chunkBuff == nil {
+		s.chunkBuff = make([]byte, bufferSize)
+	}
+	for offset := 0; offset < len(data); offset += chunkPayloadSize {
+		end := offset + chunkPayloadSize
+		if end > len(data) {
+			end = len(data)
+		}
+		s.chunkBuff[0] = chunkByte
+		if end == len(data) {
+			s.chunkBuff[1] = chunkComplete
+		} else {
+			s.chunkBuff[1] = chunkPartial
+		}
+		nc := copy(s.chunkBuff[chunkHeaderSize:], data[offset:end])
+		// FDs / credentials travel with the first chunk only.
+		chunkMsg := unixsocket.Msg{}
+		if offset == 0 {
+			chunkMsg = msg
+		}
+		if err := s.Socket.SendMsg(s.chunkBuff[:chunkHeaderSize+nc], chunkMsg); err != nil {
+			return fmt.Errorf("send msg: chunk: %w", err)
+		}
 	}
 	return nil
 }

--- a/container/socket_linux_test.go
+++ b/container/socket_linux_test.go
@@ -1,0 +1,154 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func init() {
+	Init()
+}
+
+func TestManyFilesOpen(t *testing.T) {
+	m := getEnv(t, nil)
+
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{"Small", 10},
+		{"Medium", 100},
+		{"BatchBoundary", 200},
+		{"OverBatch-300", 300},
+		{"Large-500", 500},
+		{"Large-1000", 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := make([]OpenCmd, tt.count)
+			for i := 0; i < tt.count; i++ {
+				cmds[i] = OpenCmd{
+					Path:     fmt.Sprintf("/w/test_%s_%d", tt.name, i),
+					Flag:     os.O_CREATE | os.O_WRONLY | os.O_TRUNC,
+					Perm:     0644,
+					MkdirAll: true,
+				}
+			}
+			results, err := m.Open(cmds)
+			if err != nil {
+				t.Fatalf("Open(%d files): %v", tt.count, err)
+			}
+			if len(results) != tt.count {
+				t.Fatalf("got %d results, want %d", len(results), tt.count)
+			}
+			successCount := 0
+			for i, r := range results {
+				if r.Err != nil {
+					t.Errorf("result[%d]: %v", i, r.Err)
+					continue
+				}
+				if r.File == nil {
+					t.Errorf("result[%d]: File is nil", i)
+					continue
+				}
+				r.File.Close()
+				successCount++
+			}
+			t.Logf("successfully opened %d/%d files", successCount, tt.count)
+		})
+	}
+}
+
+func TestLongPathsManyFiles(t *testing.T) {
+	m := getEnv(t, nil)
+
+	n := 200
+	longPathPrefix := "/w/very_long_directory_name_to_increase_gob_payload_size/subdir_level2/another_level"
+	cmds := make([]OpenCmd, n)
+	for i := 0; i < n; i++ {
+		cmds[i] = OpenCmd{
+			Path:     fmt.Sprintf("%s/file_number_%d_with_some_extra_padding_to_make_it_even_longer", longPathPrefix, i),
+			Flag:     os.O_CREATE | os.O_WRONLY | os.O_TRUNC,
+			Perm:     0644,
+			MkdirAll: true,
+		}
+	}
+	results, err := m.Open(cmds)
+	if err != nil {
+		t.Fatalf("Open with long paths: %v", err)
+	}
+	if len(results) != n {
+		t.Fatalf("got %d results, want %d", len(results), n)
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Errorf("result[%d]: %v", i, r.Err)
+			continue
+		}
+		if r.File != nil {
+			r.File.Close()
+		}
+	}
+}
+
+func TestOpenThenExecveManyFiles(t *testing.T) {
+	m := getEnv(t, nil)
+
+	// Open many files
+	n := 500
+	cmds := make([]OpenCmd, n)
+	for i := 0; i < n; i++ {
+		cmds[i] = OpenCmd{
+			Path:     fmt.Sprintf("/w/exectest_%d", i),
+			Flag:     os.O_CREATE | os.O_WRONLY | os.O_TRUNC,
+			Perm:     0644,
+			MkdirAll: true,
+		}
+	}
+	results, err := m.Open(cmds)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	for _, r := range results {
+		if r.File != nil {
+			r.File.Close()
+		}
+	}
+
+	// Verify container still works after many opens
+	if err := m.Ping(); err != nil {
+		t.Fatalf("Ping after many opens: %v", err)
+	}
+}
+
+func TestMixedSuccessFailure(t *testing.T) {
+	m := getEnv(t, nil)
+
+	cmds := []OpenCmd{
+		{Path: "/w/valid1", Flag: os.O_CREATE | os.O_WRONLY, Perm: 0644},
+		{Path: "/root/invalid_no_permission", Flag: os.O_CREATE | os.O_WRONLY, Perm: 0644},
+		{Path: "/w/valid2", Flag: os.O_CREATE | os.O_WRONLY, Perm: 0644},
+	}
+	results, err := m.Open(cmds)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("valid1 should succeed: %v", results[0].Err)
+	} else if results[0].File != nil {
+		results[0].File.Close()
+	}
+	if results[1].Err == nil {
+		t.Error("invalid path should fail")
+	}
+	if results[2].Err != nil {
+		t.Errorf("valid2 should succeed: %v", results[2].Err)
+	} else if results[2].File != nil {
+		results[2].File.Close()
+	}
+}


### PR DESCRIPTION
Resolves #19.

## Problem

Copying >~300 files fails for two reasons:
1. A `SOCK_SEQPACKET` datagram must fit the 32KB receive buffer, so a gob-encoded `[]OpenCmd` larger than 32KB is rejected.
2. `sendmsg` cannot carry more than `SCM_MAX_FD` (253) FDs at once.

## Changes

- **Socket framing** (`socket_linux.go`): small messages (<=32KB) are unchanged (zero header, zero-copy). Larger ones are split into `[chunkByte][flag][payload]` chunks, each within 32KB, so any size fits the kernel buffer with no `SO_RCVBUF` tuning. A gob stream never starts with a zero byte, so a leading `chunkByte` marks a chunk unambiguously. Chunks use only a `partial`/`complete` flag — `SEQPACKET` guarantees ordering, so no id/index/total is needed. FDs ride the first chunk only.
- **Open batching** (`host_cmd_linux.go`): `Open` is split into batches of 200 to stay under `SCM_MAX_FD`.

Chunking (rather than a `[grow][size]` control packet) avoids any size ceiling and keeps the hot path header-free and zero-alloc. go-judge needs no changes.
