### PR TITLE
fix(container): tighten Open FD cleanup after batching review

### DIFF
--- a/container/host_cmd_linux.go
+++ b/container/host_cmd_linux.go
@@ -59,12 +59,11 @@ func (c *container) Open(p []OpenCmd) (results []OpenCmdResult, err error) {
 	syscall.ForkLock.RLock()
 	defer syscall.ForkLock.RUnlock()
 
+	var opened []*os.File
 	defer func() {
 		if err != nil {
-			for _, res := range results {
-				if res.File != nil {
-					res.File.Close()
-				}
+			for _, f := range opened {
+				f.Close()
 			}
 		}
 	}()
@@ -104,7 +103,6 @@ func (c *container) Open(p []OpenCmd) (results []OpenCmdResult, err error) {
 				continue
 			}
 			if fdIndex >= len(msg.Fds) {
-				closeFds(msg.Fds[fdIndex:])
 				return nil, fmt.Errorf("open: mismatch between success flags and received FDs")
 			}
 			fd := msg.Fds[fdIndex]
@@ -112,10 +110,16 @@ func (c *container) Open(p []OpenCmd) (results []OpenCmdResult, err error) {
 			syscall.CloseOnExec(fd)
 			f := os.NewFile(uintptr(fd), p[offset+i].Path)
 			if f == nil {
+				syscall.Close(fd)
 				closeFds(msg.Fds[fdIndex:])
 				return nil, fmt.Errorf("open: failed to create file for fd: %d", fd)
 			}
+			opened = append(opened, f)
 			results[offset+i] = OpenCmdResult{File: f}
+		}
+		if fdIndex != len(msg.Fds) {
+			closeFds(msg.Fds[fdIndex:])
+			return nil, fmt.Errorf("open: received %d extra FDs", len(msg.Fds)-fdIndex)
 		}
 	}
 	return results, nil

--- a/container/socket_bench_test.go
+++ b/container/socket_bench_test.go
@@ -198,15 +198,20 @@ func BenchmarkSocketOpenRoundTrip(b *testing.B) {
 						return
 					}
 					fds := make([]int, 0, len(in.OpenCmd))
+					files := make([]*os.File, 0, len(in.OpenCmd))
 					closeFds(msg.Fds)
 					for _, o := range in.OpenCmd {
 						f, e := os.OpenFile(o.Path, o.Flag, o.Perm)
 						if e != nil {
 							continue
 						}
+						files = append(files, f)
 						fds = append(fds, int(f.Fd()))
 					}
 					_ = srv.SendMsg(reply{}, unixsocket.Msg{Fds: fds})
+					for _, f := range files {
+						f.Close()
+					}
 				}
 			}()
 


### PR DESCRIPTION
### Motivation

- Prevent host FD leaks when `Open` spans multiple `maxOpenPerBatch` batches by ensuring partially opened files remain closable if a later batch fails. 
- Close FDs that were consumed by `os.NewFile` failures and reject any extra FDs returned by the container to avoid protocol-error leaks. 
- Fix a benchmark FD leak that kept server-side `*os.File` handles open after `SendMsg`, which can exhaust `RLIMIT_NOFILE` during large benchmarks.

### Description

- Track successfully wrapped files in a separate `opened []*os.File` slice and defer-close those on error so partial results are preserved for cleanup instead of being lost when returning `nil, err`.
- When `os.NewFile` fails, explicitly `syscall.Close(fd)` and close any remaining `msg.Fds` to avoid leaking the consumed FD.
- Validate that the number of consumed FDs exactly matches the successes and close any extra FDs with an explicit error when `fdIndex != len(msg.Fds)`.
- Update `BenchmarkSocketOpenRoundTrip` to retain server-side `*os.File` handles until after `SendMsg` duplicates their descriptors and then close them to prevent benchmark-side FD leaks.

### Testing

- Ran `go test ./container` and it passed successfully.
- Ran `go test ./...` which fails in this execution environment due to platform/test limitations: `/sys/fs/cgroup` is read-only, `sendmsg` for unix credentials is not permitted, and `ptrace` `vmRead` is not implemented, so unrelated package tests failed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a680fbe0368832e8f1c75c37bf873a0)